### PR TITLE
http,html: format directory entries and URIs

### DIFF
--- a/tests/driver.cc
+++ b/tests/driver.cc
@@ -123,13 +123,18 @@ void testRenderDirectory(struct stats &stats) {
                         /* silent */ true) == std::nullopt,
         stats);
 
+  check("directory without trailing '/'",
+        renderDirectory("foo", dir, "{{ body }}", /* silent */ true) ==
+            std::nullopt,
+        stats);
+
   check(
       "valid dir",
       [&dir] {
         auto result =
-            renderDirectory("foo", dir, "{{ body }}", /* silent */ true);
+            renderDirectory("foo/", dir, "{{ body }}", /* silent */ true);
         return *result ==
-               R"(<h1>foo</h1>
+               R"(<h1>foo/</h1>
 <table>
 <thead>
 <tr>
@@ -139,6 +144,9 @@ void testRenderDirectory(struct stats &stats) {
 <tbody>
 <tr>
 <td><a href="foo/..">..</a></td>
+</tr>
+<tr>
+<td><a href="foo/z-sample-dir">z-sample-dir</a></td>
 </tr>
 <tr>
 <td><a href="foo/hello.md">hello.md</a></td>


### PR DESCRIPTION
This patch fixes two problems.  First, directory URIs were not always
forced to end in a '/', which caused problems in relative links.
Second, when rendering directory entries, the code did not distinguish
between sub-directories and files (and instead displayed them all in
alphabetical order).

This patch introduces a 302 redirect when the URI points to a directory
so that the URI always ends in a '/'.  This patch also sorts the
directory entries so that all sub-directories and displayed before
files.