### PR TITLE
http: listen on all available network interfaces

### DIFF
--- a/lib/src/http.cc
+++ b/lib/src/http.cc
@@ -153,7 +153,7 @@ void startWebServer(const std::filesystem::path &docRoot,
 
   auto auxData =
       auxInfo{docRoot, std::move(templateText), std::move(notFoundHtml)};
-  auto endPoint = std::string{"http://localhost:"} + std::to_string(portNumber);
+  auto endPoint = std::string{"http://0.0.0.0:"} + std::to_string(portNumber);
   mg_http_listen(&mgr, endPoint.c_str(), responseFn, &auxData);
 
   const auto timeoutMs = 1000;


### PR DESCRIPTION
Instead of listening to just the loopback network interface, listen to
all available network interfaces, so that magenta can be run on a remote
server.