### PR TITLE
CI: check for source formatting using clang-format

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,11 @@ jobs:
 
     - name: Install Prerequisites
       shell: bash
-      run: python3 -m pip install cmake ninja
+      run: python3 -m pip install clang-format cmake ninja
+
+    - name: Check Source Formatting
+      shell: bash
+      run: git fetch origin main && git clang-format origin/main --diff
 
     - name: Configure, Build, and Test (Ubuntu and macOS)
       if: ${{ matrix.target-os == 'ubuntu' || matrix.target-os == 'macos' }}

--- a/app/magenta.cc
+++ b/app/magenta.cc
@@ -57,8 +57,10 @@ struct magenta {
 
     auto config = nlohmann::json::parse(*maybeConfig);
     auto port = config["core"]["port"];
-    auto docRoot = config["core"]["docRoot"].template get<std::filesystem::path>();
-    auto templatePath = config["core"]["templatePath"].template get<std::filesystem::path>();
+    auto docRoot =
+        config["core"]["docRoot"].template get<std::filesystem::path>();
+    auto templatePath =
+        config["core"]["templatePath"].template get<std::filesystem::path>();
 
     if (!std::filesystem::exists(docRoot)) {
       std::cerr << "document root points to non-existent directory: '"


### PR DESCRIPTION
This patch makes CI check for proper source formatting on all C/C++
files that were modified by this branch compared to the main branch.