### PR TITLE
config: add elementary configuration for OAuthV2-based authentication

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,22 +5,9 @@ on:
     branches:
       - main
 
-    paths:
-      - CMakeLists.txt
-      - 'app/**'
-      - 'external/**'
-      - 'lib/**'
-      - 'tests/**'
   push:
     branches:
       - main
-
-    paths:
-      - CMakeLists.txt
-      - 'app/**'
-      - 'external/**'
-      - 'lib/**'
-      - 'tests/**'
 
   workflow_dispatch:
 
@@ -62,7 +49,12 @@ jobs:
 
     - name: Check Source Formatting
       shell: bash
-      run: git fetch origin main && git clang-format origin/main --diff
+      run: |
+        git fetch origin main
+        git clang-format origin/main --diff
+
+        python3 -m json.tool --indent=2 config.json __fmt.config.json
+        cmp -s config.json __fmt.config.json
 
     - name: Configure, Build, and Test (Ubuntu and macOS)
       if: ${{ matrix.target-os == 'ubuntu' || matrix.target-os == 'macos' }}

--- a/config.json
+++ b/config.json
@@ -3,5 +3,19 @@
     "port": 8080,
     "docRoot": "docs",
     "templatePath": "template.html"
+  },
+  "auth": {
+    "kind": "oauthv2",
+    "providers": [
+      {
+        "name": "github",
+        "allowList": [
+          "ashay"
+        ],
+        "blockList": [],
+        "clientIdEnvVar": "GITHUB_CLIENT_ID",
+        "clientSecretEnvVar": "GITHUB_CLIENT_SECRET"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This patch adds some basic configuration fields useful for
authentication/authorization using OAuthV2.  Initially, I plan to
support just GitHub as the OAuth provider, although the list should be
easy to extend.

An an ancillary change, this patch drops the file patterns that gate the
GitHub workflow run, since the workflow is required to merge PRs, but
the workflow is not run for files that are not C/C++ sources.